### PR TITLE
downgraded spark version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - ipywidgets=7.4.0
   - seaborn=0.8.1
   - pandas=0.22.0
-  - pyspark=2.4.0
+  - pyspark=2.3.1
   - py4j=0.10.7
   - pyarrow=0.9.0
   - python-dateutil


### PR DESCRIPTION
Python kernel does not start since upgrading to spark 2.4.0. Downgrading to 2.3.1 to see if that is causing the problem.