### PR TITLE
Rename 'polymer:' column in pandas representation to 'polymer'

### DIFF
--- a/mmtfPyspark/utils/mmtfStructure.py
+++ b/mmtfPyspark/utils/mmtfStructure.py
@@ -486,7 +486,7 @@ class MmtfStructure(object):
                                     'o': self.occupancy_list,
                                     'b': self.b_factor_list,
                                     'element': self.elements,
-                                    'polymer:': self.polymer
+                                    'polymer': self.polymer
                                     })
             if add_cols is not None:
                 if 'sequence_position' in add_cols:


### PR DESCRIPTION
The `mmtfStructure.to_pandas` method created a column called "polymer:". This is difficult to work with in pandas without special escaping and looks like a typo. This PR renames it without the colon.

Note that this will break existing code that references the column by the old name.